### PR TITLE
Increased NFC timeout to 3000ms for YubiKeyNeo to resolve 'Tag lost' iss...

### DIFF
--- a/src/main/com/yubico/yubioath/model/YubiKeyNeo.java
+++ b/src/main/com/yubico/yubioath/model/YubiKeyNeo.java
@@ -107,6 +107,7 @@ public class YubiKeyNeo {
         this.isoTag = isoTag;
 
         isoTag.connect();
+        isoTag.setTimeout(3000);
         byte[] resp = isoTag.transceive(SELECT_COMMAND);
         if (!compareStatus(resp, APDU_OK)) {
             throw new AppletMissingException();


### PR DESCRIPTION
...ue on my Nexus 5

As per my review on the Play Store, I was having issues with the app saying 'Error in Yubikey communication'. Increasing the timeout appears to resolve this for me.
