### PR TITLE
Added NFC intent to go straight to app

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -53,8 +53,14 @@
             android:configChanges="keyboardHidden|orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="https"
+                    android:host="my.yubico.com"
+                    android:pathPrefix="/neo/" />
             </intent-filter>
         </activity>
     </application>

--- a/src/main/com/yubico/yubioath/fragments/ListCodesFragment.java
+++ b/src/main/com/yubico/yubioath/fragments/ListCodesFragment.java
@@ -129,7 +129,7 @@ public class ListCodesFragment extends ListFragment implements MainActivity.OnYu
         //If less than 10 seconds remain until we'd get the next OTP, skip ahead.
         long timestamp = (System.currentTimeMillis() / 1000 + 10) / 30;
 
-        if(!swipeDialog.isAdded()) {
+        if(swipeDialog==null || !swipeDialog.isAdded()) {
             //If the swipeDialog has been dismissed we ignore the state and just list the OTPs.
             state = READ_LIST;
         }


### PR DESCRIPTION
One more PR from me. I thought it would be useful to go straight to the ListCodes part of the app when the YubiKey NFC intent fires. I'm not an android dev, so this code is entirely non-optimal, but it at least seems to work on my limited set of hardware.

The AndroidManifest.xml now has a filter which listens for a YubiKey neo NDEF_DISCOVERED which should load the main activity. Then, there's some code in onResume which checks the intent, and if it's NDEF_DISCOVERED runs almost the same code again as what's in onIntent. The main difference is that if the password is required, I couldn't figure out how to display the password window - getFragmentManager() seems to return null. I just show a toast instead.

So there's some duplication that's largely unnecessary. Hopefully a useful starting point for what might be quite a useful feature.
