### PR TITLE
Opt out of reader mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.fidesmo</groupId>
             <artifactId>nordpol-android</artifactId>
-            <version>0.1.8</version>
+            <version>0.1.12</version>
             <type>aar</type>
         </dependency>
     </dependencies>

--- a/src/main/com/yubico/yubioath/MainActivity.java
+++ b/src/main/com/yubico/yubioath/MainActivity.java
@@ -87,7 +87,14 @@ public class MainActivity extends Activity implements OnDiscoveredTagListener {
 
         openFragment(new SwipeListFragment());
 
-        tagDispatcher = TagDispatcher.get(this, this, false);
+        /* Set up Nordpol in the following manner:
+         * - opt out of NFC unavailable handling
+         * - opt out of disabled sounds
+         * - dispatch on UI thread
+         * - opt out of broadcom workaround (this is only available in reader mode)
+         * - opt out of reader mode completely
+         */
+        tagDispatcher = TagDispatcher.get(this, this, false, false, true, false, true);
     }
 
     @Override


### PR DESCRIPTION
- By disabling reader mode fully, the behavior of failing reads are
  identical to before
- The main reason for reader mode is its much more stable handling of
  long running transactions, OTP transactions are fairly short so can
  work well with foreground dispatch
- Broadcom workarounds need to be disabled since they are only possible
  in reader mode, but they also only affect long running transactions
- Document the Nordpol settings currently used