### PR TITLE
Fix for Xperia XZ "Error in Yubikey communication"

### DIFF
--- a/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
@@ -38,7 +38,7 @@ abstract class BaseActivity<T : BaseViewModel>(private var modelClass: Class<T>)
             } catch (e: Exception) {
                 Log.e("yubioath", "Error using NFC device", e)
             }
-        }).enableReaderMode(false).enableUnavailableNfcUserPrompt(false).build()
+        }).enableReaderMode(true).enableUnavailableNfcUserPrompt(false).build()
     }
 
     override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
This seems to fix #64 for me - it reverses the behaviour which was changed in 1.0.5. I don't know whether it will break things on other devices as I only have the Xperia XZ to test on.
