### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/dialog_require_password.xml
+++ b/app/src/main/res/layout/dialog_require_password.xml
@@ -52,6 +52,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             android:hint="@string/password"
             android:imeOptions="actionDone"
             android:maxLines="1"

--- a/app/src/main/res/layout/fragment_add_credential.xml
+++ b/app/src/main/res/layout/fragment_add_credential.xml
@@ -94,6 +94,7 @@
                 android:hint="@string/add_credential_secret"
                 android:imeOptions="actionDone"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:maxLines="1"
                 android:singleLine="true" />
 

--- a/app/src/main/res/layout/fragment_password.xml
+++ b/app/src/main/res/layout/fragment_password.xml
@@ -55,6 +55,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/old_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:imeOptions="actionNext"
                 android:maxLines="1"
                 android:singleLine="true" />
@@ -73,6 +74,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/new_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:imeOptions="actionNext"
                 android:maxLines="1"
                 android:singleLine="true" />
@@ -91,6 +93,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/verify_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:imeOptions="actionNext"
                 android:maxLines="1"
                 android:singleLine="true" />


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.