### PR TITLE
Theme options of Light and Dark

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppThemeLight">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
@@ -69,10 +69,11 @@ abstract class BaseActivity<T : BaseViewModel>(private var modelClass: Class<T>)
         }
 
         if (prefs.getString("themeSelect", null) == "Light"){
-            setTheme(android.R.style.ThemeOverlay_Material_Light)
-        }
-        else if (prefs.getString("themeSelect", null) == "Dark") {
-            setTheme(android.R.style.ThemeOverlay_Material_Dark)
+            setTheme(R.style.AppThemeLight)
+        } else if (prefs.getString("themeSelect", null) == "Dark") {
+            setTheme(R.style.AppThemeDark)
+        } else if (prefs.getString("themeSelect", null) == "AMOLED") {
+            setTheme(R.style.AppThemeAmoled)
         }
 
         viewModel = ViewModelProviders.of(this).get(modelClass)

--- a/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/com/yubico/yubioath/ui/BaseActivity.kt
@@ -68,6 +68,13 @@ abstract class BaseActivity<T : BaseViewModel>(private var modelClass: Class<T>)
             window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
         }
 
+        if (prefs.getString("themeSelect", null) == "Light"){
+            setTheme(android.R.style.ThemeOverlay_Material_Light)
+        }
+        else if (prefs.getString("themeSelect", null) == "Dark") {
+            setTheme(android.R.style.ThemeOverlay_Material_Dark)
+        }
+
         viewModel = ViewModelProviders.of(this).get(modelClass)
         nfcDispatcher = NordpolNfcDispatcher(this) {
             it.enableReaderMode(!prefs.getBoolean("disableNfcReaderMode", false)).enableUnavailableNfcUserPrompt(false)

--- a/app/src/main/kotlin/com/yubico/yubioath/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/yubico/yubioath/ui/settings/SettingsFragment.kt
@@ -41,6 +41,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, if (it == true) WindowManager.LayoutParams.FLAG_SECURE else 0)
             }
 
+            onPreferenceChange("themeSelect") {
+                recreate()
+            }
+
             onPreferenceClick("clearIcons") {
                 AlertDialog.Builder(this)
                         .setTitle(R.string.clear_icons)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -117,4 +117,9 @@
     <string-array name="defaultKeyboard">
         <item>US</item>
     </string-array>
+
+    <string-array name="themeSelection">
+        <item>Light</item>
+        <item>Dark</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -121,5 +121,6 @@
     <string-array name="themeSelection">
         <item>Light</item>
         <item>Dark</item>
+        <item>AMOLED</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,7 +3,10 @@
     <color name="yubicoPrimaryGreen">#9aca3c</color>
     <color name="yubicoPrimaryWhite">#ffffff</color>
 
-    <color name="yubicoSecondaryBlue">#284c61</color>
+    <color name="yubicoSecondaryBlue">#325f74</color>
+    <color name="yubicoDarkSecondaryBlue">#4b8fae</color>
     <color name="yubicoSecondaryLightGray">#939598</color>
-    <color name="yubicoSecondaryDarkGray">#333333</color>
+    <color name="yubicoPrimaryDarkGreen">#3e580a</color>
+    <color name="yubicoAmoledBackground">#000000</color>
+    <color name="yubicoAmoledMenu">#111111</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="hide_thumbnail_description">Don\'t show codes in the app switcher</string>
     <string name="disable_nfc_reader_mode_title">Disable NFC Reader mode</string>
     <string name="disable_nfc_reader_mode_description">This may resolve NFC issues on some handsets, but is likely to introduce them on others. Use what works best for you.</string>
+    <string name="theme_select_title">Theme</string>
     <string name="read_ndef_data_title">Read NFC NDEF payload</string>
     <string name="read_ndef_data_description">Read the OTP slot data over NFC and display it as a credential.</string>
     <string name="warn_nfc_title">NFC warnings</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,16 +1,37 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppThemeLight" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
 
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/yubicoPrimaryGreen</item>
-        <item name="colorPrimaryDark">@color/yubicoSecondaryDarkGray</item>
+        <item name="colorPrimaryDark">@color/yubicoPrimaryDarkGreen</item>
         <item name="colorAccent">@color/yubicoSecondaryBlue</item>
     </style>
 
-    <style name="activated" parent="AppTheme">
+    <style name="AppThemeDark" parent="Theme.AppCompat">
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/yubicoPrimaryGreen</item>
+        <item name="colorPrimaryDark">@color/yubicoPrimaryDarkGreen</item>
+        <item name="colorAccent">@color/yubicoDarkSecondaryBlue</item>
+    </style>
+
+    <style name="AppThemeAmoled" parent="Theme.AppCompat">
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@android:color/black</item>
+        <item name="colorPrimaryDark">@android:color/black</item>
+        <item name="colorAccent">@color/yubicoDarkSecondaryBlue</item>
+        <!--<item name="android:background">@android:color/black</item>-->
+        <item name="android:windowBackground">@color/yubicoAmoledBackground</item>
+        <item name="android:itemBackground">@color/yubicoAmoledMenu</item>
+    </style>
+
+    <style name="activated" parent="AppThemeLight">
         <item name="android:background">?android:attr/activatedBackgroundIndicator</item>
     </style>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -32,6 +32,14 @@
         android:summary="@string/disable_nfc_reader_mode_description"
         android:title="@string/disable_nfc_reader_mode_title" />
 
+    <ListPreference
+        android:defaultValue="Light"
+        android:entries="@array/themeSelection"
+        android:entryValues="@array/themeSelection"
+        android:key="themeSelect"
+        android:summary="%s"
+        android:title="@string/theme_select_title" />
+
     <Preference
         android:key="clearIcons"
         android:title="@string/clear_icons_action" />


### PR DESCRIPTION
Note: There is a system call that uses API 21 (released 2014)

I used the `recreate()` method to help the theme transition in the settings section (current screen), but closing the app and reopening helps display the theme that was selected.